### PR TITLE
change  chain_id from 1024 to 1020

### DIFF
--- a/lib/structs.js
+++ b/lib/structs.js
@@ -13,7 +13,7 @@ class Tx {
         this.publisher = "";
         this.publisher_sigs = [];
         this.amount_limit = [];
-        this.chain_id = 1024;
+        this.chain_id = 1020;
         this.reserved = null;
     }
 


### PR DESCRIPTION
Version 3.1.0 of the blockchain has a chain id of 1020 and the SDK had the old value of 2014.